### PR TITLE
add ecosystem config

### DIFF
--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -1,0 +1,13 @@
+module.exports = {
+    apps: [
+      {
+        name: "nextjs-dev",
+        script: "node_modules/.bin/next",
+        args: "dev -p 3000",
+        env: {
+          NODE_ENV: "development",
+        },
+      },
+    ],
+  };
+  


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds PM2 ecosystem.config.js to run the Next.js dev server under PM2. Defines nextjs-dev (next dev -p 3000, NODE_ENV=development) for simpler local process management.

<!-- End of auto-generated description by cubic. -->

